### PR TITLE
electron renderer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "src"
   ],
   "scripts": {
-    "test": "mocha --compilers js:babel-register",
+    "test": "npm run lint && npm run test:node && npm run test:renderer",
+    "test:node": "mocha --compilers js:babel-register",
+    "test:renderer": "electron-mocha --renderer --compilers js:babel-register",
     "lint": "eslint src test",
     "compile": "babel src --out-dir lib",
     "prepublish": "npm run compile"
@@ -30,6 +32,8 @@
     "babel-preset-stage-2": "^6.11.0",
     "babel-preset-latest": "^6.16.0",
     "babel-register": "^6.9.0",
+    "electron-mocha": "^3.0.5",
+    "electron-prebuilt": "^1.3.4",
     "eslint": "^3.7.1",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-plugin-import": "^1.16.0",


### PR DESCRIPTION
`npm run test` now runs the test suite both in node and inside a renderer process in electron.