### PR TITLE
ci: inline reusable workflows from private repo

### DIFF
--- a/.github/workflows/block-fixup.yml
+++ b/.github/workflows/block-fixup.yml
@@ -5,8 +5,31 @@ on: [pull_request]
 permissions: {}
 
 jobs:
-  git-check:
+  block-fixup:
+    name: Block Fixup Commits
+    runs-on: ubuntu-latest
     permissions:
       contents: read # checkout
       pull-requests: read # inspect PR commit list for fixup commits
-    uses: raywhite/github-workflows/.github/workflows/pull_request_git_block_fixup.yml@111c6eaa4f9484aa66d6de6023cc43e1f1f82770 # v3.1.2
+    steps:
+      - name: Block Fixup Commit Merge
+        timeout-minutes: 2
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "::error::This workflow must be triggered by a pull_request event."
+            exit 1
+          fi
+          subjects=$(gh api --paginate \
+            "repos/${PR_REPO}/pulls/${PR_NUMBER}/commits" \
+            --jq '.[] | "\(.sha) \(.commit.message | split("\n") | .[0])"')
+          offenders=$(printf '%s\n' "$subjects" | grep -E '^[0-9a-f]{40} (fixup|squash|amend)!' || true)
+          if [ -n "$offenders" ]; then
+            echo "::error::Found fixup/squash/amend commits — autosquash before merging:"
+            printf '%s\n' "$offenders"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,37 @@ permissions: {}
 jobs:
   release:
     name: Release
+    runs-on: arc-runner-set
+    environment: release
     permissions:
       actions: write # allows triggering actions in opened PRs
       contents: write # to create release (changesets/action)
       id-token: write # required for provenance and oidc publish
       pull-requests: write # to create pull request (changesets/action)
-    uses: raywhite/github-workflows/.github/workflows/push_changeset_release_publish.yml@111c6eaa4f9484aa66d6de6023cc43e1f1f82770 # v3.1.2
-    with:
-      environment: release
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install tools via mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: '2026.5.12'
+
+      - name: Install Dependencies
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+          npm ci
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        with:
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,12 +37,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # `--format=github` emits annotations on PRs (limit 10 per step).
         # `--min-severity=medium` gates on med+ findings; info/low advisory.
-        # `--no-online-audits` skips audits that require GitHub API access
-        # (impostor-commit, ref-version-mismatch, known-vulnerable-actions).
-        # We do this because git.yml references raywhite/github-workflows,
-        # a sibling private repo our runner's GITHUB_TOKEN can't read tags
-        # for, which causes the impostor-commit audit to hard-fail (not
-        # just produce a suppressible finding). Local devs still run the
-        # online audits via `mise run lint-actions` (gh auth token has org
-        # access). Tracked in raywhite/github-workflows#21.
-        run: mise exec -- zizmor --format=github --min-severity=medium --no-online-audits .
+        run: mise exec -- zizmor --format=github --min-severity=medium .


### PR DESCRIPTION
## Why

The public \`pico-dom\` repo called reusable workflows hosted in the private \`raywhite/github-workflows\` repo. The runner's \`GITHUB_TOKEN\` has no read access to that repo, so GitHub fails the run at parse time — **"workflow was not found"** — before any job executes. This broke \`release.yml\` on every push to \`main\` ([failing run](https://github.com/raywhite/pico-dom/actions/runs/27867920668)).

## What

Inline both callers so they no longer reference the private repo:

- **\`release.yml\`** — the changeset publish job (mise + \`changesets/action\`).
- **\`block-fixup.yml\`** — the PR fixup/squash/amend commit guard.
- **\`zizmor.yml\`** — with no private reference left, dropped \`--no-online-audits\` and its rationale comment, re-enabling the online audits (impostor-commit, ref-version-mismatch, known-vulnerable-actions).

Two intentional deviations from the upstream originals, both to satisfy zizmor:
- \`persist-credentials: false\` on the release checkout.
- \`NPM_TOKEN\` moved into an \`env\` block rather than inlined into the run script (avoids template-injection finding).

> [!IMPORTANT]
> The inlined release job keeps \`environment: release\`. The \`release\` environment and its \`NPM_TOKEN\` secret must exist on **this** repo (previously the secret was just passed through to the private reusable workflow). Confirm both are configured before merging, or the publish step will fail.

## Review order

1. \`.github/workflows/release.yml\` — the broken caller, now self-contained.
2. \`.github/workflows/block-fixup.yml\` — same pattern, simpler.
3. \`.github/workflows/zizmor.yml\` — online audits re-enabled.

## Testing

- \`mise run lint-actions\` (zizmor with full online audits via org-scoped \`gh\` token): **No findings to report** (2 expected \`self-hosted-runner\` suppressions).
- Parse-time failure resolved: no workflow references the private repo (\`grep -rn github-workflows .github/\` is clean).
- \`block-fixup.yml\` exercises on this PR's \`pull_request\` event.
- Release flow can only be fully verified on merge to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)