### PR TITLE
Type node predicates as type guards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parseFragment, parse as _parse, serialize, treeAdapters } from 'parse5';
 
-import type { Attribute, Node, PicoAdapter, Props } from './types';
+import type { Attribute, Node, PicoAdapter, Props, RootNode } from './types';
 
 /**
  * This entire module interacts (parses from, transforms,
@@ -60,7 +60,7 @@ export function stringify(model: Node): string {
  *
  * @param node - a node
  */
-adapter.isRootNode = function (node: Node): boolean {
+adapter.isRootNode = function (node: Node): node is RootNode {
   return node.type === 'root';
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,9 +92,9 @@ export type PicoAdapter = {
   insertText(parentNode: Node, text: string): void;
   insertTextBefore(parentNode: Node, text: string, referenceNode: Node): void;
   adoptAttributes(recipient: Node, attrs: Attribute[]): void;
-  isCommentNode(node: Node): boolean;
-  isElementNode(node: Node): boolean;
-  isTextNode(node: Node): boolean;
+  isCommentNode(node: Node): node is CommentNode;
+  isElementNode(node: Node): node is ElementNode;
+  isTextNode(node: Node): node is TextNode;
   isDocumentTypeNode(node: Node): boolean;
 
   // Overridden by the source (signatures preserved).
@@ -103,7 +103,7 @@ export type PicoAdapter = {
   cloneNode(node: Node): Node;
 
   // Added by the source.
-  isRootNode(node: Node): boolean;
+  isRootNode(node: Node): node is RootNode;
   createTextNode(text: string): TextNode;
   createNode(
     tagName: string | ((props: Props) => Node),


### PR DESCRIPTION
## Summary

Retype the adapter's node predicates as TypeScript [type guards](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) so consumers can narrow `Node` instead of casting.

`PicoAdapter`'s predicates previously returned plain `boolean`:

```ts
isElementNode(node: Node): boolean
```

They now return `node is X`:

```ts
isElementNode(node: Node): node is ElementNode
isTextNode(node: Node):    node is TextNode
isCommentNode(node: Node): node is CommentNode
isRootNode(node: Node):    node is RootNode
```

This means `if (adapter.isElementNode(node)) { /* node: ElementNode here */ }` narrows automatically. Downstream (e.g. `@raywhite/markup`) currently carries ~9 `as ElementNode` / `as Node` casts that exist *solely* because the old `boolean` return didn't narrow — those casts can now be removed.

## Behaviour

Runtime is **unchanged**. The checks are already sound discriminants on `node.type` (`'tag'`/`'text'`/`'comment'`/`'root'`), so the predicates are valid:

- `isElementNode`/`isTextNode`/`isCommentNode` come from parse5's htmlparser2 adapter — only the `PicoAdapter` *type* changed.
- `isRootNode` is pico-dom's own (`return node.type === 'root'`); only its return *annotation* moved from `boolean` to `node is RootNode`. Same expression.

## Tests

`npm test` — 37/37 green. `npm run build` confirms the guards in the generated `lib/index.d.ts`.

Small follow-up to the TypeScript migration (#6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
